### PR TITLE
Add a listener for the socket 'error' event

### DIFF
--- a/lib/Connection/SamsungTvConnection.js
+++ b/lib/Connection/SamsungTvConnection.js
@@ -111,6 +111,11 @@ const openSocket = (config, identity, eventEmitter) => {
       socket.on('close', () => {
         eventEmitter.emit(SamsungTvEvents.DISCONNECTED)
       })
+
+      socket.on('error', (err) => {
+        console.error('An error has occurred with the socket connection', err)
+      })
+
       return socket
     })
     .catch(err => {


### PR DESCRIPTION
This commit avoids crashes due to error `ECONNRESET` when a client disconnects

See also https://github.com/websockets/ws/issues/1256